### PR TITLE
タスク詳細ページ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { Route, Routes } from "react-router-dom";
 import Homepage from "./pages/home";
 import TaskListPage from "./pages/tasks/taskListPage";
+import TaskDetailPage from "./pages/tasks/taskDetailPage";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Homepage />} />
       <Route path="/tasks" element={<TaskListPage />} />{/* タスク一覧ページへのルート */}
+      <Route path="/tasks/:id" element={<TaskDetailPage />} />{/* タスク詳細ページへのルート */}
     </Routes>
   );
 }

--- a/src/features/tasks/components/TaskCard.tsx
+++ b/src/features/tasks/components/TaskCard.tsx
@@ -1,33 +1,15 @@
 import { Link } from "react-router-dom";
-import { Priority, Task } from "../../../types/task";
+// import { Priority, Task } from "../../../types/task"; 
 import styles from "../styles/taskCard.module.css";
+import { getPriorityClass } from "../utils/priority";
+import { getStatusLabel } from "../utils/status-label";
+import { Task } from "../../../types/task";
 
 type Props = {
     task: Task;
 };
 
 export default function TaskCard({ task }: Props) {
-
-    // タスクの優先度に応じたクラス名・スタイルを返す関数
-    // Priority TSで定義した型
-    const getPriorityClass = (priority: Priority): string => {
-        switch (priority.toLowerCase()) {
-            case "high":
-                return styles.highPriority
-            case "midium":
-                return styles.midiumPriority
-            case "low":
-                return styles.lowPriority
-            default:
-                return styles.defaultPriority
-        }
-    }
-
-    // タスクのステータスに応じた表示ラベル・スタイルを返す関数
-    const getStatusLabel = (status: boolean): string => {
-        return status ? "完了" : "未完了";
-    };
-
     return (
       <div className={styles.taskCard}>
         <Link to={`/tasks/${task.id}`} className={styles.detailLink}>
@@ -36,11 +18,10 @@ export default function TaskCard({ task }: Props) {
         <p className={`${styles.badge} ${task.status ? styles.completed : styles.incomplete}`}>
           {getStatusLabel(task.status)}
         </p>
-        <p className={`${styles.badge} ${getPriorityClass(task.priority)}`}>{task.priority}</p>
+        <p className={`${styles.badge} ${getPriorityClass(task.priority, styles)}`}>{task.priority}</p>
         <p className={styles.taskDueDate}>{task.dueDate}</p>
       </div>
     );
 }
-// タスクオステータスに応じてスタイルを適用
-// <Link to={`/tasks/${task.id}`}>詳細</Link>
+// タスクのステータスに応じてスタイルを適用
 //　可読性を向上するためのコンポーネント分割

--- a/src/features/tasks/components/TaskDetail.tsx
+++ b/src/features/tasks/components/TaskDetail.tsx
@@ -1,0 +1,50 @@
+import { Link } from "react-router-dom";
+// import { Priority, Task } from "../../../types/task";
+import styles from "../styles/taskDetail.module.css";
+import { getPriorityClass } from "../utils/priority";
+import { getStatusLabel } from "../utils/status-label";
+import { Task } from "../../../types/task";
+
+type Props = {
+    task: Task;
+};  
+
+export default function TaskDetail({ task }: Props) {
+    return (
+        <div className={styles.container}>
+            <h1 className={styles.title}>{task.title}</h1>
+            <p className={styles.description}>{task.description}</p>
+            <p className={styles.info}>
+                ステータス:{" "}
+                <span 
+                className={`${styles.badge} ${
+                    task.status ? styles.completed : styles.incomplete
+                }`}
+                >
+                {getStatusLabel(task.status)}
+                </span>
+            </p>
+            <p className={styles.info}>
+                優先度 :{" "}
+                <span className={`${styles.badge} ${getPriorityClass(task.priority, styles)}`}> 
+                {task.priority}
+                </span>
+            </p>    
+            <p className={styles.info}>期限日: {task.dueDate}</p>
+            <p className={styles.info}>
+                作成日: {new Date(task.createdAt).toLocaleString()}
+            </p>
+            <p className={styles.info}>
+                更新日: {new Date(task.updatedAt).toLocaleString()}
+            </p>
+            <div className={styles.links}>
+                <Link to={`/tasks/${task.id}/edit`} className={styles.editLink}>
+                    タスクを編集
+                </Link>
+                <Link to="/tasks" className={styles.backLink}>
+                    戻る
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/src/features/tasks/containers/TaskDetailContainer.tsx
+++ b/src/features/tasks/containers/TaskDetailContainer.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getTaskById } from "../hooks/getTaskById";
+import { Task } from "../../../types/task";
+import TaskDetail from "../components/TaskDetail";
+import styles from "../styles/taskDetail.module.css";
+
+export default function TaskDetailContainer() {
+    const { id } = useParams<{ id?: string }>();
+    // URLパラメータからタスクIDを取得
+    const [task, setTask] = useState<Task | null>(null);
+    // task の状態　まだ取得できていない間は null →　取得後に Task 型のデータで更新
+    //「task は null か Task のどちらかの型である」と明確に定義　→　コードの安全性を高めている
+
+    // useEffect コンポーネントがマウントされた時にgetTaskById関数を実行してタスク情報を取得
+    // getTaskById関数に、URLパラメータから取得したタスクIDを引数に渡すことで、指定されたタスクの情報を取得できる
+    useEffect(() => {
+        if(!id) return;
+
+        async function fetchTask() {
+            const fetchedTask = await getTaskById(id);
+            setTask(fetchedTask ?? null);
+        }
+        fetchTask();
+    }, [id]);
+    // setTask(fetchedTask ?? null);
+    // 取得されたタスクが undefined の場合もあるため、?? 演算子で null に置き換え、安全に扱えるようにしている
+    
+    if (!task) {
+        return (
+            <div        
+            style={{
+                display: "flex",
+                justifyContent: "center",
+                marginTop: "300px",
+            }}
+            >
+                読みこみ中...
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.taskDetailContainer}>
+            <TaskDetail task={task} /> {/* 取得したタスク情報をTaskDetailコンポーネントに渡す */}
+        </div>
+    );
+}
+// タスク情報が取得できていない場合は、ローディング表示
+

--- a/src/features/tasks/hooks/getTaskById.ts
+++ b/src/features/tasks/hooks/getTaskById.ts
@@ -1,0 +1,18 @@
+import { Task } from "../../../types/task";
+import { mockTasks } from "../mocks/task";
+
+export const getTaskById = (id?: string): Promise<Task | undefined> => {
+    if(!id) return Promise.resolve(undefined);
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const task = mockTasks.find((task) => task.id === Number.parseInt(id));
+            resolve(task);
+        }, 500); 
+    });
+};
+
+// getTaskById関数　指定されたタスクIDのタスク情報を取得する
+// 引数で受け取っているid URLパラメータから取得したタスクID
+// 関数を使用するコンポーネントでURLパラメータから取得したタスクIDを複数に渡して使う
+// 関数の戻り値として Promise<Task | undefined> を指定
+// 非同期にTask型のデータor該当するタスクがない場合はundefinedを返す

--- a/src/features/tasks/styles/taskDetail.module.css
+++ b/src/features/tasks/styles/taskDetail.module.css
@@ -1,0 +1,93 @@
+.taskDetailContainer {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.container {
+  width: 100%;
+  margin: 4rem auto 0;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  font-family: Arial, sans-serif;
+}
+
+.title {
+  font-size: 2.5rem;
+  color: #333;
+  margin-bottom: 1rem;
+  margin-top: 0;
+}
+
+.description {
+  font-size: 1.2rem;
+  color: #555;
+  margin-bottom: 1.5rem;
+}
+
+.info {
+  font-size: 1rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.links {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.editLink {
+  background-color: #0070f3;
+  color: white;
+  padding: 0.8rem 1.2rem;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.backLink {
+  background-color: #6b7280;
+  color: white;
+  padding: 0.8rem 1.2rem;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.editLink:hover,
+.backLink:hover {
+  opacity: 0.8;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-align: center;
+}
+
+.completed {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.incomplete {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.highPriority {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.mediumPriority {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.lowPriority {
+  background-color: #d1fae5;
+  color: #065f46;
+}

--- a/src/features/tasks/utils/priority.ts
+++ b/src/features/tasks/utils/priority.ts
@@ -1,0 +1,18 @@
+import { Priority } from "../../../types/task";
+    // タスクの優先度に応じたクラス名・スタイルを返す関数
+    // Priority TSで定義した型
+    export const getPriorityClass = (
+    priority: Priority,
+    styles: Record<string, string>    
+    ): string => {
+    switch (priority.toLowerCase()) {
+        case "high":
+            return styles.highPriority
+        case "medium":
+            return styles.mediumPriority
+        case "low":
+            return styles.lowPriority
+        default:
+            return styles.defaultPriority
+    }
+};

--- a/src/features/tasks/utils/status-label.ts
+++ b/src/features/tasks/utils/status-label.ts
@@ -1,0 +1,3 @@
+export const getStatusLabel = (status: boolean): string => {
+    return status ? "完了" : "未完了";
+};

--- a/src/pages/tasks/taskDetailPage.tsx
+++ b/src/pages/tasks/taskDetailPage.tsx
@@ -1,0 +1,9 @@
+import TaskDetailContainer from "../../features/tasks/containers/TaskDetailContainer";
+
+export default function TaskDetailPage() {
+    return (
+        <div>
+            <TaskDetailContainer />
+        </div>
+    );
+}


### PR DESCRIPTION
- タスク一覧からタスクタイトルをクリックするとTaskDetailPageコンポーネントを取得しタスク詳細画面に遷移する

1.  TaskDetailContainerコンポーネントでタスク一覧から詳細画面への切り替え、タスク情報を取得するためのgetTaskById関数を読み込む。タスク情報を取得できた場合はTaskDetailコンポーネントを取得
2. TaskDetailコンポーネントでタスクの詳細情報を表示するためのフレーム＆各情報を表示
3. getPriorityClassとgetStatusLabel関数を切出し、TaskDetailコンポーネント・TaskCardコンポーネントにimport

[![Image from Gyazo](https://i.gyazo.com/07aa568b1b6a0873cc5c1a2892288f32.png)](https://gyazo.com/07aa568b1b6a0873cc5c1a2892288f32)